### PR TITLE
Error when you enter c-mode for the first time (Emacs 24)

### DIFF
--- a/lisp/ethan-wspace.el
+++ b/lisp/ethan-wspace.el
@@ -312,7 +312,8 @@ This supercedes (require 'show-wspace) and show-ws-highlight-tabs."
   (if ethan-wspace-highlight-tabs-mode
       (font-lock-add-keywords nil (list ethan-wspace-type-tabs-keyword))
     (font-lock-remove-keywords nil (list ethan-wspace-type-tabs-keyword)))
-  (font-lock-fontify-buffer))
+  (when font-lock-mode ; may be not initialized yet
+    (font-lock-fontify-buffer)))
 
 (ethan-wspace-declare-type tabs :find ethan-wspace-type-tabs-find
                            :clean ethan-wspace-untabify :highlight ethan-wspace-highlight-tabs-mode


### PR DESCRIPTION
Open fresh Emacs, type M-x find-function RET search-forward RET, see:

`c-font-lock-fontify-region: Symbol's function definition is void: nil`

This works if you have Emacs sources lying nearby, otherwise just open some C file.

Not sure if the problem is present in the release version, but it's been in trunk for some time.
