### PR TITLE
Add autoload cookie to global-ethan-wspace-mode and random whitespace

### DIFF
--- a/lisp/ethan-wspace.el
+++ b/lisp/ethan-wspace.el
@@ -737,6 +737,7 @@ This just activates each whitespace type in this buffer."
   (when (buffer-file-name)
     (ethan-wspace-mode 1)))
 
+;;;###autoload
 (define-global-minor-mode global-ethan-wspace-mode
   ethan-wspace-mode ethan-wspace-is-buffer-appropriate
   :init-value t)


### PR DESCRIPTION
Relax! j/k about the whitespace.

The autoload cookie is necessary so we can run `global-ethan-wspace-mode` without an explicit `require`.

I also took the libert of submitting a recipe for ethan-wspace to Melpa, if you have this package repository configured you can just do `M-x package-install ethan-wspace` and you're good to go. 
