### PR TITLE
Attempt to preserve the position of point when cleaning a buffer.

### DIFF
--- a/lisp/ethan-wspace.el
+++ b/lisp/ethan-wspace.el
@@ -387,14 +387,15 @@ This internally uses `show-trailing-whitespace'."
   ;(message "eol-clean")
   (let ((line-before-point
          (buffer-substring (line-beginning-position) (point))))
-    (save-restriction
-      (narrow-to-region begin end)
-      (delete-trailing-whitespace)
-      ;; Save the whitespace that was removed immediately before point; we'll
-      ;; restore it in the :fixup function.
-      (let* ((new-line-len (- (point) (line-beginning-position)))
-             (removed-ws (substring line-before-point new-line-len)))
-        (setq ethan-wspace-type-eol-clean-fixup-stash removed-ws)))))
+    ;; It's critical to specify begin and end explicitly, because
+    ;; delete-trailing-whitespace has a special case: if 'end' is nil, it also
+    ;; deletes eof trailing newlines.
+    (delete-trailing-whitespace begin end)
+    ;; Save the whitespace that was removed immediately before point; we'll
+    ;; restore it in the :fixup function.
+    (let* ((new-line-len (- (point) (line-beginning-position)))
+           (removed-ws (substring line-before-point new-line-len)))
+      (setq ethan-wspace-type-eol-clean-fixup-stash removed-ws))))
 
 (defun ethan-wspace-type-eol-clean-fixup ()
   (let ((whitespace-to-add ethan-wspace-type-eol-clean-fixup-stash)


### PR DESCRIPTION
Closes: #15

This commit does three things:
- Adds a new :clean-fixup function to the general cleaner framework,
  which is called from the after-save hook.
- Defines a :clean-fixup function for eol whitespace, which restores
  any whitespace immediately preceding point.
- Defines a :clean-fixup function for many-nls-eof whitespace, which
  restores newlines at the end of the file if this is necessary to
  preserve the position of point.

This seems to work great EXCEPT that if at the end of your file you
have in order: (a) several newlines, (b) several horizontal whitespace
characters, (c) point -- then the newlines, but not the horizontal
whitespace, will disappear on save. I'm not sure what the correct fix
for this is, because it appears to reflect a more fundamental bug in
ethan-wspace. The problem is that the eol whitespace cleaner also
cleans extraneous eof newlines. E.g., add several newlines at the end
of a file, make sure your modeline says "ew:Mnlt", and then save. The
newlines will be cleaned, even though trailing newlines are in
highlight-don't-clean mode. But my fixup code assumes that the eol cleaner only modifies individual lines.

So what causes the bug in this commit is: first the many-nls-eof
cleaner runs, and does nothing. Then the eol cleaner runs, and deletes
not just the trailing whitespace on the current line, but all the
preceding blank lines. Then, my fixup code runs, and re-inserts the
trailing whitespace, but not the trailing blank lines.

Option A ("correct"): fix the eol cleaner so it never deletes whole
lines. Also make sure that it runs before the eof cleaners, because it
might change where the eof is. Now the code in this commit will
magically start working.

Option B ("expedient"): add an explicit workaround to the eol fixup
code that checks for this situation explicitly, and re-adds newlines
in this case.

Thoughts?
