### PR TITLE
Fix typerrors in latest version.

### DIFF
--- a/lisp/ethan-wspace.el
+++ b/lisp/ethan-wspace.el
@@ -412,7 +412,8 @@ FIXME: maybe we should just write our own."
   (let ((whitespace-to-add ethan-wspace-type-eol-clean-fixup-stash)
         (was-modified (buffer-modified-p)))
     ;(message "eol-clean-fixup: restoring '%s'" whitespace-to-add)
-    (insert whitespace-to-add)
+    (when whitespace-to-add
+        (insert whitespace-to-add))
     (set-buffer-modified-p was-modified)))
 
 (ethan-wspace-declare-type eol :find ethan-wspace-type-eol-find
@@ -535,7 +536,7 @@ With arg, turn highlighting on if arg is positive, off otherwise."
         (cons (- max (1- trailing-newlines)) max)
       nil)))
 
-(defvar ethan-wspace-type-many-nls-eof-clean-fixup-stash nil
+(defvar ethan-wspace-type-many-nls-eof-clean-fixup-stash 0
   "Internal variable storing fixup information for many-nls-eof cleaning")
 (make-variable-buffer-local 'ethan-wspace-type-nls-eof-clean-fixup-stash)
 


### PR DESCRIPTION
- The added WHEN fixes a bug where we would try to run `(insert NIL)`,
  which obviously fails.
- The change to the defvar fixes a failing typecheck, somewhere, where a
  `wholenump` was expected.

I just fixed this quickly because these bugs prevented me from updating other packages, when their sources were checked for whitespace errors.  I was hoping you could add the appropriate tests yourself to make sure this stays fixed, as I don't have the time right now.
