### PR TITLE
Do not enable ethan-whitespace for buffers with no-conversion coding system

### DIFF
--- a/lisp/ethan-wspace.el
+++ b/lisp/ethan-wspace.el
@@ -830,7 +830,8 @@ other code has turned on `require-final-newline'.")
 
 (defun ethan-wspace-is-buffer-appropriate ()
   ;;; FIXME: not OK for diff mode, non-file modes, etc?
-  (when (buffer-file-name)
+  (when (and (buffer-file-name)
+             (not (eq buffer-file-coding-system 'no-conversion)))
     (ethan-wspace-mode 1)))
 
 ;;;###autoload


### PR DESCRIPTION
From the manual: 

> the coding system ‘no-conversion’ specifies no character code conversion at all—none for non-ASCII byte values and none for end of line.  This is useful for reading or writing binary files, tar files, and other files that must be examined verbatim.