### PR TITLE
Highlight no newline at eof to width of window, not frame.

### DIFF
--- a/lisp/ethan-wspace.el
+++ b/lisp/ethan-wspace.el
@@ -511,7 +511,7 @@ With arg, turn highlighting on if arg is positive, off otherwise."
     (save-excursion
       (move-overlay ethan-wspace-highlight-no-nl-eof-overlay (point-max) (point-max))
       (goto-char (point-max))
-      (let* ((str-len (- (frame-width) (current-column)
+      (let* ((str-len (- (window-width) (current-column)
                          1))  ; subtract one so that we don't trigger line-wrap
              (str (concat "eof" (make-string (max 0 (- str-len 3)) ?\ ))))
         (set-text-properties 0 (max 0 str-len) '(face ethan-wspace-face) str)


### PR DESCRIPTION
Highlighting no newline at EOF when frame is split horizontally does not look good. Fix by highlighting to window-width, not frame-width. 