### PR TITLE
Run cleaners in a specific order

### DIFF
--- a/lisp/ethan-wspace.el
+++ b/lisp/ethan-wspace.el
@@ -845,9 +845,15 @@ other code has turned on `require-final-newline'.")
 
 (defun ethan-wspace-clean-before-save-hook ()
   (when ethan-wspace-mode
-    (dolist (type ethan-wspace-errors)
-      (when (ethan-wspace-type-clean-mode-active type)
-          (ethan-wspace-type-clean type)))))
+    ;; many-nls-eof cleanup can be confused if the last line has spaces on
+    ;; it, so run eol first.
+    (let ((ordered-errors
+           (if (not (member 'eol ethan-wspace-errors))
+               ethan-wspace-errors
+             (cons 'eol (remove 'eol ethan-wspace-errors)))))
+      (dolist (type ordered-errors)
+        (when (ethan-wspace-type-clean-mode-active type)
+          (ethan-wspace-type-clean type))))))
 
 (add-hook 'before-save-hook 'ethan-wspace-clean-before-save-hook)
 


### PR DESCRIPTION
I discovered several newlines at EOF today. With a little experimentation I was able to reproduce it with several blank lines, the last of which containing several space characters. The problem is that `many-nls-eof` runs first, and skips backwards until the first non-newline character. `eol` running first is enough to fix it. I think all the other whitespace error types are compatible -- these are the only two where some contention is possible.

This issue was anticipated as far back as #16 but this is the first time I've knowingly experienced it.
